### PR TITLE
Remove mention of Darwin mlock support from docs.

### DIFF
--- a/website/source/docs/configuration/index.html.md
+++ b/website/source/docs/configuration/index.html.md
@@ -74,8 +74,8 @@ to specify where the configuration is.
 
     Disabling `mlock` is not recommended unless the systems running Vault only
     use encrypted swap or do not use swap at all. Vault only supports memory
-    locking on UNIX-like systems (Linux, FreeBSD, Darwin, etc). Non-UNIX like
-    systems (e.g. Windows, NaCL, Android) lack the primitives to keep a
+    locking on UNIX-like systems that support the mlock() syscall (Linux, FreeBSD, etc). 
+    Non-UNIX like systems (e.g. Windows, NaCL, Android) lack the primitives to keep a
     process's entire memory address space from spilling to disk and is therefore
     automatically disabled on unsupported platforms.
 


### PR DESCRIPTION
According to #2119, mlock isn't actually supported on darwin, so this should probably be clarified.